### PR TITLE
Add kex-angebote-api to supported APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Mit dieser API lässt sich ein OAuth Access Token anfordern, mit dem andere Euro
 ⚠️ *ACHTUNG* Diese API ist neu und befindet sich gerade in der Pilotierung. An folgenden APIs kann das neue Access Token schon verwendet werden:
 * [BaufiSmart Vorgänge API](https://github.com/europace/baufismart-vorgaenge-api)
 * [KreditSmart KEX Vorgang Export API](https://github.com/europace/kex-vorgang-export-api)
+* [KreditSmart KEX Angebote API](https://github.com/europace/kex-angebote-api)
 
 
 ## Grundlegendes


### PR DESCRIPTION
Wir wollen die KEX Angebote API nur mit OAuth2 unterstützen. Bisher haben wir dort nur einen Kunden, daher würden wir diese API gerne mit in die Liste aufnehmen