### PR TITLE
[Github Actions] Check von YAML-Dateien und Generierung von Markdown aus europace_security.yaml

### DIFF
--- a/.github/workflows/build_merge.yaml
+++ b/.github/workflows/build_merge.yaml
@@ -1,0 +1,38 @@
+name: "Check yaml with Linter"
+
+on:
+  push:
+    branches: 
+      - master
+  
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pyyaml
+        
+      - name: Check yaml files
+        run: |
+          yamllint -c .github/workflows/config/yamllint.yaml --no-warnings .
+        
+      - name: Commit files
+        run: |
+          echo ${{ github.ref }}
+          git add .
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git commit -m "Updated Scopes Doc" -a | exit 0
+    
+      - name: Push changes
+        if: github.ref == 'refs/heads/master'
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/config/yamllint.yaml
+++ b/.github/workflows/config/yamllint.yaml
@@ -1,0 +1,8 @@
+# This is a configuration file for yamllint!
+# It extends the default conf by adjusting some options.
+
+extends: default
+
+rules:
+  trailing-spaces: disable
+  line-length: disable

--- a/.github/workflows/scopes-doc.yaml
+++ b/.github/workflows/scopes-doc.yaml
@@ -19,7 +19,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install pyyaml
         
-      - name: Check yaml files
+      - name: Transform YAML to Doc
         run: |
           python .github/workflows/scripts/scopes-doc.py -i europace_security.yaml > docs/scopes.md
         

--- a/.github/workflows/scopes-doc.yaml
+++ b/.github/workflows/scopes-doc.yaml
@@ -1,4 +1,4 @@
-name: "Check yaml with Linter"
+name: "Create Scopes Doc"
 
 on:
   push:
@@ -21,7 +21,7 @@ jobs:
         
       - name: Check yaml files
         run: |
-          yamllint -c .github/workflows/config/yamllint.yaml --no-warnings .
+          python .github/workflows/scripts/scopes-doc.py -i europace_security.yaml > docs/scopes.md
         
       - name: Commit files
         run: |

--- a/.github/workflows/scopes-doc.yaml
+++ b/.github/workflows/scopes-doc.yaml
@@ -6,7 +6,7 @@ on:
       - master
   
 jobs:
-  build:
+  create-docs:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/scripts/scopes-doc.py
+++ b/.github/workflows/scripts/scopes-doc.py
@@ -9,7 +9,7 @@ def transformScopesToMarkDown(input):
 
     intro="""# Scopes für OAuth Clients bei Europace
 
-Mithilfe von Scopes können Sie genau angeben, welche Art von Zugriff Sie benötigen. Scopes beschränken den Zugriff für OAuth-Token. Sie gewähren keine zusätzlichen Berechtigungen über das hinaus, was der Benutzer bereits hat.
+Mithilfe von Scopes kannst du genau angeben, welche Art von Zugriff du benötigst. Scopes beschränken den Zugriff für OAuth-Token. Sie gewähren keine zusätzlichen Berechtigungen über das hinaus, was der Benutzer bereits hat.
 
 ## Verfügbare Scopes
 

--- a/.github/workflows/scripts/scopes-doc.py
+++ b/.github/workflows/scripts/scopes-doc.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+
+import sys
+import yaml
+from optparse import OptionParser
+
+def transformScopesToMarkDown(input):
+    scopes = input["flows"]["clientCredentials"]["scopes"].copy()
+
+    intro="""# Scopes für OAuth Clients bei Europace
+
+Mithilfe von Scopes können Sie genau angeben, welche Art von Zugriff Sie benötigen. Scopes beschränken den Zugriff für OAuth-Token. Sie gewähren keine zusätzlichen Berechtigungen über das hinaus, was der Benutzer bereits hat.
+
+## Verfügbare Scopes
+
+Die nachfolgende Tabelle stellt eine Liste, der aktuell verfügbaren Scopes dar.
+
+| Name | Beschreibung  |
+| --- | ---  |"""
+
+    print(intro)
+    for scope in scopes:
+        print('| `', scope, '` | ', scopes[scope].replace('##', '').replace('\n', ' ').replace('\r', '').rstrip(), ' |')
+
+def printScopes(inputfile):
+    with open(inputfile) as stream:
+        europace_security = ''
+        try:
+            europace_security = yaml.safe_load(stream)
+        except yaml.YAMLError as exc:
+            print(exc)
+
+        transformScopesToMarkDown(europace_security)
+
+def main():
+    parser = OptionParser()
+    parser.add_option("-i", "--input", dest="input", metavar="FILE")
+
+    (options, args) = parser.parse_args()
+    inputfile = options.input
+
+    printScopes(inputfile)
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/yaml-lint.yml
+++ b/.github/workflows/yaml-lint.yml
@@ -1,0 +1,29 @@
+name: "Check yaml with Linter"
+
+on:
+  push:
+    branches: 
+      - master
+  pull_request:
+    branches: 
+      - master
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install yamllint
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        
+      - name: Check yaml files
+        run: |
+          yamllint -c .github/workflows/config/yamllint.yaml --no-warnings .

--- a/docs/scopes.md
+++ b/docs/scopes.md
@@ -1,0 +1,34 @@
+# Scopes für OAuth Clients bei Europace
+
+Mithilfe von Scopes können Sie genau angeben, welche Art von Zugriff Sie benötigen. Scopes beschränken den Zugriff für OAuth-Token. Sie gewähren keine zusätzlichen Berechtigungen über das hinaus, was der Benutzer bereits hat.
+
+## Verfügbare Scopes
+
+Die nachfolgende Tabelle stellt eine Liste, der aktuell verfügbaren Scopes dar.
+
+| Name | Beschreibung  |
+| --- | ---  |
+| ` partner:plakette:anlegen ` |   Darf neue Plaketten anlegen. TODO Beschreibung  |
+| ` partner:plakette:loeschen ` |   Darf Plaketten löschen TODO Beschreibung  |
+| ` partner:plakette:lesen ` |   Darf Partner-Daten lesen TODO Beschreibung  |
+| ` partner:plakette:schreiben ` |   Darf Partner-Daten schreiben TODO Beschreibung  |
+| ` partner:beziehungen:lesen ` |   Darf Beziehungen zwischen Partnern lesen TODO Beschreibung  |
+| ` partner:beziehungen:schreiben ` |   Darf Beziehungen zwischen Partnern schreiben TODO Beschreibung  |
+| ` partner:rechte:lesen ` |   Darf Rechte eines Partners lesen TODO Beschreibung  |
+| ` partner:rechte:schreiben ` |   Darf Rechte eines Partners schreiben TODO Beschreibung  |
+| ` reporting:rohdaten:lesen ` |   Darf im Partnermanagement den Rohdaten-Report runterladen TODO Beschreibung  |
+| ` reporting:produktanbieterreport:lesen ` |   Darf im Partnermanagement den produktanbieterreport runterladen TODO Beschreibung  |
+| ` baufi-vertrieb:echtgeschaeft ` |   Baufinanzierung-Echtgeschäft bearbeiten  |
+| ` baufi-vertrieb:vorgang:lesen ` |   Baufinanzierungsvorgänge lesen  |
+| ` baufi-vertrieb:vorgang:schreiben ` |   Baufinanzierungsvorgänge schreiben  |
+| ` baufi-vertrieb:vorgang:anlegen ` |   Baufinanzierungsvorgänge anlegen  |
+| ` baufi-vertrieb:vorgang:loeschen ` |   Baufinanzierungsvorgänge löschen  |
+| ` baufinanzierung:antrag:lesen ` |   Baufinanzierungsanträge lesen  |
+| ` baufinanzierung:antrag:schreiben ` |   Baufinanzierungsanträge schreiben  |
+| ` privatkredit:angebot:ermitteln ` |   Kreditsmartangebote ermitteln  |
+| ` privatkredit:antrag:schreiben ` |   Kreditsmartanträge schreiben  |
+| ` privatkredit:vorgang:lesen ` |   Kreditsmartvorgänge lesen  |
+| ` privatkredit:vorgang:schreiben ` |   Kreditsmartvorgänge schreiben  |
+| ` impersonieren ` |   Impersonieren  |
+| ` openid ` |   Benutzer-Login durchführen  |
+| ` profile ` |   Benutzerprofil lesen  |

--- a/docs/scopes.md
+++ b/docs/scopes.md
@@ -1,6 +1,6 @@
 # Scopes für OAuth Clients bei Europace
 
-Mithilfe von Scopes können Sie genau angeben, welche Art von Zugriff Sie benötigen. Scopes beschränken den Zugriff für OAuth-Token. Sie gewähren keine zusätzlichen Berechtigungen über das hinaus, was der Benutzer bereits hat.
+Mithilfe von Scopes kannst du genau angeben, welche Art von Zugriff du benötigst. Scopes beschränken den Zugriff für OAuth-Token. Sie gewähren keine zusätzlichen Berechtigungen über das hinaus, was der Benutzer bereits hat.
 
 ## Verfügbare Scopes
 


### PR DESCRIPTION
### Motivation

Damit die YAML-Dateien, insbesondere `europace_security.yaml`, nicht fälschlicherweise ein invalides Format aufweisen, soll mittels Linter die Dateien geprüft werden.

Darüber soll eine leserliche Form der Scopes-Übersicht bereit gestellt werden. (closes https://europace.atlassian.net/browse/PARTNER-118)

### Änderungen

Neue Github Action hinzugefügt, um YAML Dateien zu üperprüfen.
Neue Github Action hinzugefügt, um aus `europace_security.yaml` eine MarkDown-Datei zu erzeugen.