### PR TITLE
[BER-366] Benennt Scopes zum Baufi Vorgang um

### DIFF
--- a/europace_security.yaml
+++ b/europace_security.yaml
@@ -93,16 +93,12 @@ flows:
         ## Benutzerprofil lesen
 
     requiredAuthorities:
-      baufi-vertrieb:echtgeschaeft:
+      baufinanzierung:echtgeschaeft:
         - BS_SICHTBAR
         - ECHTES_GESCHAEFT_ERLAUBT
-      baufi-vertrieb:vorgang:lesen:
+      baufinanzierung:vorgang:lesen:
         - BS_SICHTBAR
-      baufi-vertrieb:vorgang:schreiben:
-        - BS_SICHTBAR
-      baufi-vertrieb:vorgang:anlegen:
-        - BS_SICHTBAR
-      baufi-vertrieb:vorgang:loeschen:
+      baufinanzierung:vorgang:schreiben:
         - BS_SICHTBAR
       baufinanzierung:ereignis:lesen:
         - BS_SICHTBAR


### PR DESCRIPTION
Closes https://europace.atlassian.net/browse/BER-366

## Motivation
Der Vorgänge-Edge-Server wurde durch das Partnermanagement-Team als Beispiel für die Umstellung auf OAuth 2 mit Scopes ausgestattet.
Mittlerweile wurde für die Namensfindung der Scopes ein Schema festgelegt.

Die momentan im Vorgänge-Edge-Server verwendeten Scopes passen nicht zu dem Namensschema. Entsprechend ist eine Umbenennung erforderlich. Aufgrund dessen sollen in diesem Ticket die Scopes umbenannt werden

## Changes
Die Scopes wurden umbenannt.
Die Scopes `baufi-vertrieb:vorgang:anlegen` und `baufi-vertrieb:vorgang:loeschen` wurden entfernt, da diese nicht in Verwendung sind.

## Test
keine
