### PR TITLE
[DUCK-1014] scopes für die Unterlagen API

### DIFF
--- a/europace_security.yaml
+++ b/europace_security.yaml
@@ -97,7 +97,7 @@ flows:
         Der Client kann freigegebene Unterlagen zu einem Antrag abrufen
       unterlagen:freigabe:write: |
         ## Freigegebene Unterlagen aktualisieren
-        Der Client kann den Status einer freigegeben Unterlagen setzen, um aus Bankensicht den Empfang der Unterlagen zu bestätigen.
+        Der Client kann den Status einer freigegeben Unterlagen setzen, um aus Produktanbietersicht den Empfang der Unterlagen zu bestätigen.
 
       impersonieren: |
         ## Darf Impersonieren

--- a/europace_security.yaml
+++ b/europace_security.yaml
@@ -79,7 +79,7 @@ flows:
         ## Dokumente lesen
         Der Client kann hochgeladene Dokumente eines Vorgangs abrufen.
       unterlagen:dokument:schreiben: |
-        ## Dokumente umbenennen und löschen
+        ## Dokumente schreiben und kategorisieren
         Der Client kann Dokumente zu einem Vorgang hochladen, umbenennen, löschen und die Kategorisierung anstoßen, damit die Dokumente in der Unterlagenakte zu Verfügung stehen.
       unterlagen:unterlage:lesen: |
         ## Unterlagen lesen

--- a/europace_security.yaml
+++ b/europace_security.yaml
@@ -97,7 +97,7 @@ flows:
         Der Client kann freigegebene Unterlagen zu einem Antrag abrufen
       unterlagen:freigabe:write: |
         ## Freigegebene Unterlagen aktualisieren
-        Der Client kann den Status einer freigegeben Unterlagen setzen, um den aus Bankensicht den Empfang der Unterlagen zu bestätigen.
+        Der Client kann den Status einer freigegeben Unterlagen setzen, um aus Bankensicht den Empfang der Unterlagen zu bestätigen.
 
       impersonieren: |
         ## Darf Impersonieren

--- a/europace_security.yaml
+++ b/europace_security.yaml
@@ -75,14 +75,12 @@ flows:
       privatkredit:vorgang:schreiben: |
         ## Kreditsmartvorgänge schreiben
 
-      unterlagen:dokument:hochladen: |
-        ## Dokumente hochladen
-        Der Client kann Dokumente zu einem Vorgang hochladen und die Kategorisierung anstoßen, damit die Dokumente in der Unterlagenakte zu Verfügung stehen.
       unterlagen:dokument:lesen: |
         ## Dokumente lesen
         Der Client kann hochgeladene Dokumente eines Vorgangs abrufen.
       unterlagen:dokument:schreiben: |
         ## Dokumente umbenennen und löschen
+        Der Client kann Dokumente zu einem Vorgang hochladen, umbenennen, löschen und die Kategorisierung anstoßen, damit die Dokumente in der Unterlagenakte zu Verfügung stehen.
       unterlagen:unterlage:lesen: |
         ## Unterlagen lesen
         Der Client kann die kategorisierten Dokumente (Unterlagen) abrufen.

--- a/europace_security.yaml
+++ b/europace_security.yaml
@@ -75,27 +75,27 @@ flows:
       privatkredit:vorgang:schreiben: |
         ## Kreditsmartvorgänge schreiben
 
-      unterlagen:dokument:upload: |
+      unterlagen:dokument:hochladen: |
         ## Dokumente hochladen
         Der Client kann Dokumente zu einem Vorgang hochladen und die Kategorisierung anstoßen, damit die Dokumente in der Unterlagenakte zu Verfügung stehen.
-      unterlagen:dokument:read: |
+      unterlagen:dokument:lesen: |
         ## Dokumente lesen
         Der Client kann hochgeladene Dokumente eines Vorgangs abrufen.
-      unterlagen:dokument:write: |
+      unterlagen:dokument:schreiben: |
         ## Dokumente umbenennen und löschen
-      unterlagen:unterlage:read: |
+      unterlagen:unterlage:lesen: |
         ## Unterlagen lesen
         Der Client kann die kategorisierten Dokumente (Unterlagen) abrufen.
-      unterlagen:unterlage:write: |
+      unterlagen:unterlage:schreiben: |
         ## Unterlagen neu zuordnen
         Der Client kann die Kategorie und den Bezug der Unterlagen ändern.
       unterlagen:unterlage:freigeben: |
         ## Unterlagen freigeben
         Der Client kann Unterlagen für einen Antrag freigeben.
-      unterlagen:freigabe:read: |
+      unterlagen:freigabe:lesen: |
         ## Freigegebene Unterlagen lesen
         Der Client kann freigegebene Unterlagen zu einem Antrag abrufen
-      unterlagen:freigabe:write: |
+      unterlagen:freigabe:schreiben: |
         ## Freigegebene Unterlagen aktualisieren
         Der Client kann den Status einer freigegeben Unterlagen setzen, um aus Produktanbietersicht den Empfang der Unterlagen zu bestätigen.
 

--- a/europace_security.yaml
+++ b/europace_security.yaml
@@ -75,6 +75,30 @@ flows:
       privatkredit:vorgang:schreiben: |
         ## Kreditsmartvorgänge schreiben
 
+      unterlagen:dokument:upload: |
+        ## Dokumente hochladen
+        Der Client kann Dokumente zu einem Vorgang hochladen und die Kategorisierung anstoßen, damit die Dokumente in der Unterlagenakte zu Verfügung stehen.
+      unterlagen:dokument:read: |
+        ## Dokumente lesen
+        Der Client kann hochgeladene Dokumente eines Vorgangs abrufen.
+      unterlagen:dokument:write: |
+        ## Dokumente umbenennen und löschen
+      unterlagen:unterlage:read: |
+        ## Unterlagen lesen
+        Der Client kann die kategorisierten Dokumente (Unterlagen) abrufen.
+      unterlagen:unterlage:write: |
+        ## Unterlagen neu zuordnen
+        Der Client kann die Kategorie und den Bezug der Unterlagen ändern.
+      unterlagen:unterlage:freigeben: |
+        ## Unterlagen freigeben
+        Der Client kann Unterlagen für einen Antrag freigeben.
+      unterlagen:freigabe:read: |
+        ## Freigegebene Unterlagen lesen
+        Der Client kann freigegebene Unterlagen zu einem Antrag abrufen
+      unterlagen:freigabe:write: |
+        ## Freigegebene Unterlagen aktualisieren
+        Der Client kann den Status einer freigegeben Unterlagen setzen, um den aus Bankensicht den Empfang der Unterlagen zu bestätigen.
+
       impersonieren: |
         ## Darf Impersonieren
         Eine Aktion wird im Namen eines Partners ausgeführt wobei die Autorisierung des Clients durch einen übergeordneten Partner erfolgt.


### PR DESCRIPTION
## Motivation
Die Scopes die wir für die UnterlagenAPI verwenden wollen.

Ich habe mich für eine eigene Domäne entschieden, da unsere API nicht exclusiv Baufismart oder Kreditsmart zuzuordnen ist, sondern beiden Frontends und auch das BOXL Frontend wird unterstützt. Also ähnlich übergreifend arbeitet wie das Partnermanagement.

Bei den Scopes hab ich mich an bekannte usesecase orientiert. Es gibt clients die nur hochladen (Finn), es gibt Clients die die Bearbeitung und Freigabe der Unterlagen machen (UAkte) und es gibt Clients die die Freiageb abrufen (Allianz,PSD,..)

Verwendung der scopes https://github.com/europace/unterlagen-api/pull/42