### PR TITLE
Rename reporting report

### DIFF
--- a/docs/scopes.md
+++ b/docs/scopes.md
@@ -17,7 +17,7 @@ Die nachfolgende Tabelle stellt eine Liste, der aktuell verfügbaren Scopes dar.
 | ` partner:rechte:lesen ` |   Darf Rechte eines Partners lesen  |
 | ` partner:rechte:schreiben ` |   Darf Rechte eines Partners schreiben  |
 | ` report:rohdaten:lesen ` |   Darf den Rohdaten-Report runterladen  |
-| ` report:produktanbieterreport:lesen ` |   Darf den Produktanbieter-Report runterladen  |
+| ` report:produktanbieter:lesen ` |   Darf den Produktanbieter-Report runterladen  |
 | ` baufinanzierung:echtgeschaeft ` |   Baufinanzierung-Echtgeschäft bearbeiten  |
 | ` baufinanzierung:vorgang:lesen ` |   Baufinanzierungsvorgänge lesen  |
 | ` baufinanzierung:vorgang:schreiben ` |   Baufinanzierungsvorgänge schreiben  |

--- a/docs/scopes.md
+++ b/docs/scopes.md
@@ -16,8 +16,8 @@ Die nachfolgende Tabelle stellt eine Liste, der aktuell verfügbaren Scopes dar.
 | ` partner:beziehungen:schreiben ` |   Darf Beziehungen zwischen Partnern schreiben Erlaubt es unter anderem UebernahmeRecht, Administrierbare und Uebernehmbare zu schreiben  |
 | ` partner:rechte:lesen ` |   Darf Rechte eines Partners lesen  |
 | ` partner:rechte:schreiben ` |   Darf Rechte eines Partners schreiben  |
-| ` reporting:rohdaten:lesen ` |   Darf den Rohdaten-Report runterladen  |
-| ` reporting:produktanbieterreport:lesen ` |   Darf den Produktanbieter-Report runterladen  |
+| ` report:rohdaten:lesen ` |   Darf den Rohdaten-Report runterladen  |
+| ` report:produktanbieterreport:lesen ` |   Darf den Produktanbieter-Report runterladen  |
 | ` baufinanzierung:echtgeschaeft ` |   Baufinanzierung-Echtgeschäft bearbeiten  |
 | ` baufinanzierung:vorgang:lesen ` |   Baufinanzierungsvorgänge lesen  |
 | ` baufinanzierung:vorgang:schreiben ` |   Baufinanzierungsvorgänge schreiben  |

--- a/docs/scopes.md
+++ b/docs/scopes.md
@@ -16,8 +16,8 @@ Die nachfolgende Tabelle stellt eine Liste, der aktuell verfügbaren Scopes dar.
 | ` partner:beziehungen:schreiben ` |   Darf Beziehungen zwischen Partnern schreiben Erlaubt es unter anderem UebernahmeRecht, Administrierbare und Uebernehmbare zu schreiben  |
 | ` partner:rechte:lesen ` |   Darf Rechte eines Partners lesen  |
 | ` partner:rechte:schreiben ` |   Darf Rechte eines Partners schreiben  |
-| ` report:rohdaten:lesen ` |   Darf den Rohdaten-Report runterladen  |
-| ` report:produktanbieter:lesen ` |   Darf den Produktanbieter-Report runterladen  |
+| ` reporting:rohdaten:lesen ` |   Darf den Rohdaten-Report runterladen  |
+| ` reporting:produktanbieterreport:lesen ` |   Darf den Produktanbieter-Report runterladen  |
 | ` baufinanzierung:echtgeschaeft ` |   Baufinanzierung-Echtgeschäft bearbeiten  |
 | ` baufinanzierung:vorgang:lesen ` |   Baufinanzierungsvorgänge lesen  |
 | ` baufinanzierung:vorgang:schreiben ` |   Baufinanzierungsvorgänge schreiben  |

--- a/europace_security.yaml
+++ b/europace_security.yaml
@@ -34,7 +34,7 @@ flows:
 
       report:rohdaten:lesen: |
         ## Darf den Rohdaten-Report runterladen
-      report:produktanbieterreport:lesen: |
+      report:produktanbieter:lesen: |
         ## Darf den Produktanbieter-Report runterladen
 
       baufinanzierung:echtgeschaeft: |

--- a/europace_security.yaml
+++ b/europace_security.yaml
@@ -32,9 +32,9 @@ flows:
       partner:rechte:schreiben: |
         ## Darf Rechte eines Partners schreiben
 
-      reporting:rohdaten:lesen: |
+      report:rohdaten:lesen: |
         ## Darf den Rohdaten-Report runterladen
-      reporting:produktanbieterreport:lesen: |
+      report:produktanbieterreport:lesen: |
         ## Darf den Produktanbieter-Report runterladen
 
       baufinanzierung:echtgeschaeft: |


### PR DESCRIPTION
Es ist angestrebt, dass Token Scopes mit dem API Context (\<context\>.api.europace.de) 1:1 übereinstimmen.

Darum wollen wir (Data)`reporting.{reporttyp}.lesen` in `report.{reporttyp}.lesen` umbenennen.

In diesem Zuge wurde auch der Scope vom Produktanbieterreport in `report.produktanbieter.lesen` umbenannt.
