### PR TITLE
Finman und Genopace Support ergänzt

### DIFF
--- a/docs/migrationguide_de.md
+++ b/docs/migrationguide_de.md
@@ -35,7 +35,7 @@ Die meisten HTTP Clients unterstützen OAuth2 bereits, lediglich Client_ID, Clie
 <a href="mailto:helpdesk@europace2.de?subject=Registrierung API-Client&body=Hallo,%0D%0Abitte%20registriert%20einen%20API-Client%20für%20mich.%0D%0A%0D%0APartnerID:%0D%0AClient-Name:%0D%0AClient-Beschreibung:%0D%0Atechnische%20Kontakt-Email-Adresse:%0D%0Akurze%20Beschreibung%20des%20Anwendungsfalls:%0D%0Abenötigte%20Scopes:%0D%0A%0D%0AVielen%20Dank">zur Client-Registrierung</a>
 
 
-Bitte wende dich an <a href="mailto:helpdesk@europace2.de?subject=Registrierung API-Client&body=Hallo,%0D%0Abitte%20registriert%20einen%20API-Client%20für%20mich.%0D%0A%0D%0APartnerID:%0D%0AClient-Name:%0D%0AClient-Beschreibung:%0D%0Atechnische%20Kontakt-Email-Adresse:%0D%0Akurze%20Beschreibung%20des%20Anwendungsfalls:%0D%0Abenötigte%20Scopes:%0D%0A%0D%0AVielen%20Dank">helpdesk@europace.de</a> mit folgenden Daten:
+Bitte wende dich an <a href="mailto:helpdesk@europace2.de?subject=Registrierung API-Client&body=Hallo,%0D%0Abitte%20registriert%20einen%20API-Client%20für%20mich.%0D%0A%0D%0APartnerID:%0D%0AClient-Name:%0D%0AClient-Beschreibung:%0D%0Atechnische%20Kontakt-Email-Adresse:%0D%0Akurze%20Beschreibung%20des%20Anwendungsfalls:%0D%0Abenötigte%20Scopes:%0D%0A%0D%0AVielen%20Dank">helpdesk@europace.de</a> (bzw. [kundenservice@genopace.de](mailto:kundenservice@genopace.de) oder [support@finmas.de](mailto:support@finmas.de)) mit folgenden Daten:
 - EP2-PartnerId
 - Client-Name
 - Client-Beschreibung:


### PR DESCRIPTION
Aus einem Ticket habe ich erfahren, dass Finmas Nutzer verständlicherweise verwirrt sind, wenn sie an den Europace Support schreiben, um einen Client zu bekommen, wir aber dann das Ticket schließen mit dem Hinweis, sie mögen sich an Finmas wenden.

Ich habe jetzt nur "nackte" `mailto:` Links genommen, um die Readability to gewährleisten