### PR TITLE
2 Partnermanagement Scopes gelöscht

### DIFF
--- a/docs/scopes.md
+++ b/docs/scopes.md
@@ -9,9 +9,7 @@ Die nachfolgende Tabelle stellt eine Liste, der aktuell verfügbaren Scopes dar.
 | Name | Beschreibung  |
 | --- | ---  |
 | ` partner:plakette:anlegen ` |   Darf neue Plaketten anlegen.  |
-| ` partner:plakette:loeschen ` |   Darf Plaketten löschen  |
 | ` partner:plakette:lesen ` |   Darf Partner-Daten lesen  |
-| ` partner:plakette:schreiben ` |   Darf Partner-Daten schreiben  |
 | ` partner:beziehungen:lesen ` |   Darf Beziehungen zwischen Partnern lesen Erlaubt es unter anderem UebernahmeRecht, Administrierbare und Uebernehmbare abzurufen  |
 | ` partner:beziehungen:schreiben ` |   Darf Beziehungen zwischen Partnern schreiben Erlaubt es unter anderem UebernahmeRecht, Administrierbare und Uebernehmbare zu schreiben  |
 | ` partner:rechte:lesen ` |   Darf Rechte eines Partners lesen  |


### PR DESCRIPTION
Nicht verwendete Scopes sollten gelöscht werden weil:
* Sie erwecken falsche Erwartungen
* Sie führen zu erhöhtem Kognitiven Overhead in UI und Doku

JIRA Ticket https://europace.atlassian.net/browse/PARTNER-519