### PR TITLE
Falschen Scope gelöscht

### DIFF
--- a/europace_security.yaml
+++ b/europace_security.yaml
@@ -17,7 +17,7 @@ flows:
         ## Darf neue Plaketten anlegen.
       partner:plakette:lesen: |
         ## Darf Partner-Daten lesen
-      partner:plakette:schreiben: |	
+      partner:plakette:schreiben: |
         ## Darf Partner-Daten schreiben
       partner:beziehungen:lesen: |
         ## Darf Beziehungen zwischen Partnern lesen

--- a/europace_security.yaml
+++ b/europace_security.yaml
@@ -17,12 +17,11 @@ flows:
         ## Darf neue Plaketten anlegen.
       partner:plakette:lesen: |
         ## Darf Partner-Daten lesen
+      partner:plakette:schreiben: |	
+        ## Darf Partner-Daten schreiben
       partner:beziehungen:lesen: |
         ## Darf Beziehungen zwischen Partnern lesen
         Erlaubt es unter anderem UebernahmeRecht, Administrierbare und Uebernehmbare abzurufen
-      partner:beziehungen:schreiben: |
-        ## Darf Beziehungen zwischen Partnern schreiben
-        Erlaubt es unter anderem UebernahmeRecht, Administrierbare und Uebernehmbare zu schreiben
       partner:rechte:lesen: |
         ## Darf Rechte eines Partners lesen
       partner:rechte:schreiben: |


### PR DESCRIPTION
Habe irrtümlich den falschen Scope gelöscht. Habe ihr nun wieder hergestellt und richtigen Scope gelöscht