### PR TITLE
Impersonieren: Bedingungen vom Client konkreter beschrieben

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,10 +119,9 @@ curl --location --request POST 'https://api.europace.de/auth/token' \
 
 Parameter | Beschreibung |
 --------- | :--- |
-Subject   | die Partnerid des anzumeldenden Benutzers
-Actor     | die Partnerid des registrierten Clients
-Hinweis   | die Actor-Partnerid muss in der Partnermanagementstruktur über der Subject-Partnerid angeordnet sein, da sonst die notwendigen Zugriffsrechte fehlen. Es können beliebig viele Ebenen zwischen den Partnerids liegen.
-Scope     | muss impersonieren enthalten (Hinweis: Wenn ein Scope angegeben wird, müssen alle erforderlichen Rechte angegeben werden, d.h. impersonieren allein macht keinen Sinn.)
+Subject   | die PartnerID des anzumeldenden Benutzers
+Actor     | die PartnerID des registrierten Clients<br/><br/>Hinweis: Die Actor-Partnerid muss in der Partnermanagementstruktur über der Subject-Partnerid angeordnet sein, da sonst die notwendigen Zugriffsrechte fehlen. Es können beliebig viele Ebenen zwischen den Partnerids liegen.
+Scope     | benötigten Scopes des Tokens<br/><br/>Hinweis: Der Scope `impersonieren` muss immer enthalten sein. Alle angegebenen Scopes müssen beim Client aktiviert sein.
 
 ## Nutzungsbedingungen
 Die APIs werden unter folgenden [Nutzungsbedingungen](https://docs.api.europace.de/nutzungsbedingungen/) zur Verfügung gestellt.

--- a/README.md
+++ b/README.md
@@ -120,8 +120,8 @@ curl --location --request POST 'https://api.europace.de/auth/token' \
 Parameter | Beschreibung |
 --------- | :--- |
 Subject   | die PartnerID des anzumeldenden Benutzers
-Actor     | die PartnerID des registrierten Clients<br/><br/>Hinweis: Die Actor-Partnerid muss in der Partnermanagementstruktur über der Subject-Partnerid angeordnet sein, da sonst die notwendigen Zugriffsrechte fehlen. Es können beliebig viele Ebenen zwischen den Partnerids liegen.
-Scope     | benötigten Scopes des Tokens<br/><br/>Hinweis: Der Scope `impersonieren` muss immer enthalten sein. Alle angegebenen Scopes müssen beim Client aktiviert sein.
+Actor     | die PartnerID des registrierten Clients<br/><br/>**Hinweis**: Die Actor-Partnerid muss in der Partnermanagementstruktur über der Subject-Partnerid angeordnet sein, da sonst die notwendigen Zugriffsrechte fehlen. Es können beliebig viele Ebenen zwischen den Partnerids liegen.
+Scope     | benötigten Scopes des Tokens<br/><br/>**Hinweis**: Der Scope `impersonieren` muss immer enthalten sein. Alle angegebenen Scopes müssen beim Client aktiviert sein.
 
 ## Nutzungsbedingungen
 Die APIs werden unter folgenden [Nutzungsbedingungen](https://docs.api.europace.de/nutzungsbedingungen/) zur Verfügung gestellt.


### PR DESCRIPTION
Beim Impersonieren ist uns aufgefallen, dass die benötigten Scopes beim API Client aktiviert sein müssen. Das habe ich in der Doku nachgetragen.