### PR TITLE
Migrationsguide auf der Website veröffentlicht

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Die Authorization-API stellt die Authentifizierung bei Europace für APIs zur Ve
 [![YAML](https://img.shields.io/badge/OAS-YAML-lightgrey)](https://github.com/europace/authorization-api/blob/master/authorization.yaml)
 
 **Migrationsguide** \
-Als Unterstützung für den Wechsel von den bisherigen Authentifizierungsverfahre auf OAuth2 gibt es diesen [Migrationsguide](https://github.com/europace/authorization-api/blob/master/docs/migrationguide_de.md) ([english version](https://github.com/europace/authorization-api/blob/master/docs/migrationguide_en.md)).
+Als Unterstützung für den Wechsel von den bisherigen Authentifizierungsverfahre auf OAuth2 gibt es diesen [Migrationsguide](https://docs.api.europace.de/baufinanzierung/authentifizierung/oauth-migrationsguide) ([english version](https://docs.api.europace.de/baufinanzierung/authentifizierung/oauth-migrationsguide_en)).
 
 ## Anwendungsfälle
 - Benutzer anmelden, um Europace-APIs zu verwenden


### PR DESCRIPTION
-Link auf Migrationsguide in Api-Website geändert