### PR TITLE
DOK-14 & DOK15: neue  Dokumentenverwaltung-Scopes

### DIFF
--- a/europace_security.yaml
+++ b/europace_security.yaml
@@ -84,6 +84,13 @@ flows:
       privatkredit:vorgang:schreiben: |
         ## KreditSmart-Vorgänge anlegen
 
+      dokumente:dokument:lesen: |
+        ## Dokumente herunterladen
+        Dokumente können aus einem Vorgang oder Antrag gelesen (heruntergeladen) werden
+      dokumente:dokument:schreiben: |
+        ## Dokumente hinzufügen
+        Dokumente können zu einem Vorgang oder Antrag hinzugefügt (hochgeladen) werden
+
       unterlagen:dokument:lesen: |
         ## Unterlagendokumente herunterladen
         Hochgeladene Dokumente eines Vorgangs können heruntergeladen werden.


### PR DESCRIPTION
### Motivation

Die Endpunkte zum downloaden & uploaden von Dokumenten im Core sollen mit Scopes abgesichert sein. Hierzu definieren wir zwei neue Scopes.

| Scopes | Name | Beschreibung |
|---------|--------------------------|-------------------------------------------------------|
|`dokumente:dokument:lesen`| Dokumente herunterladen | Dokumente können aus einem Vorgang oder Antrag gelesen (heruntergeladen) werden |
| `dokumente:dokument:schreiben` | Dokumente hinzufügen | Dokumente können zu einem Vorgang oder Antrag hinzugefügt (hochgeladen) werden |

Issue:https://github.com/hypoport/ep2-core/issues/4598