### PR TITLE
Adapt naming of `privatkredit:vorgang:schreiben` und `privatkredit:antrag:schreiben`

### DIFF
--- a/europace_security.yaml
+++ b/europace_security.yaml
@@ -80,12 +80,13 @@ flows:
         ## KreditSmart-Angebote ermitteln
         Ratenkredit-Angebote und -Schaufensterkonditionen können ermittelt werden.
       privatkredit:antrag:schreiben: |
-        ## KreditSmart-Anträge verändern
-        Der Antragsstatus kann verändert oder der aktuelle Status um Zusatzinformationen ergänzt werden.
+        ## KreditSmart-Anträge anlegen/verändern
+        Anträge anlegen (annehmen) oder verändern (z.B. Antragsstatus).
       privatkredit:vorgang:lesen: |
         ## KreditSmart-Vorgänge lesen
       privatkredit:vorgang:schreiben: |
-        ## KreditSmart-Vorgänge anlegen
+        ## KreditSmart-Vorgänge anlegen/verändern
+        Vorgänge anlegen oder verändern.
 
       dokumente:dokument:lesen: |
         ## Dokumente herunterladen


### PR DESCRIPTION
Dieser Scope wird sowohl für die [import-api](https://docs.api.europace.de/privatkredit/vorgaenge/kex-vorgang-import-api/#authentifizierung) als auch für die [update-API](https://docs.api.europace.de/privatkredit/vorgaenge/kex-vorgang-update-api/#authentifizierung) verwendet. Auch die [kex-angebote-api](https://docs.api.europace.de/privatkredit/angebote/kex-angebote-api/#authentifizierung) benutzt es, was aber auch als vorgang-update zählt

`KreditSmart-Vorgänge anlegen` finde ich da etwas verwirrend.

Analog geht es hier auch um Kreditsmart-Anträge verändern.
Ein Vorschlag ist hier per PR eingefügt.Gerne kann man über das Naming nochmal diskutieren

- [ ] kex-angebote-api anpassen
- [ ] kex-vorgang-import anpassen
- [ ] kex-vorgang-update anpassen