### PR TITLE
[PARTNER-714] Erstelle Scope `partner:login:silent-sign-in`

### DIFF
--- a/europace_security.yaml
+++ b/europace_security.yaml
@@ -31,7 +31,7 @@ flows:
       partner:rechte:schreiben: |
         ## Partner-Rechte verändern
       partner:zugang:silent-sign-on: |partner:login:silent-sign-in
-        ## Silent-Sign-On erlaubt
+        ## Silent-Sign-In erlaubt
         Ermöglicht das öffnen von Europace im Browser ohne Passwortabfrage.
 
       report:rohdaten:lesen: |

--- a/europace_security.yaml
+++ b/europace_security.yaml
@@ -30,7 +30,7 @@ flows:
         ## Partner-Rechte lesen
       partner:rechte:schreiben: |
         ## Partner-Rechte verändern
-      partner:zugang:silent-sign-on: |
+      partner:zugang:silent-sign-on: |partner:login:silent-sign-in
         ## Silent-Sign-On erlaubt
         Ermöglicht das öffnen von Europace im Browser ohne Passwortabfrage.
 

--- a/europace_security.yaml
+++ b/europace_security.yaml
@@ -30,7 +30,10 @@ flows:
         ## Partner-Rechte lesen
       partner:rechte:schreiben: |
         ## Partner-Rechte verändern
-        
+      partner:zugang:silent-sign-on: |
+        ## Silent-Sign-On
+        Der Benutzer kann über die Silent-Sign-On API eingeloggt werden.
+
       report:rohdaten:lesen: |
         ## Vertriebs-Rohdaten-Report abrufen
       report:produktanbieter:lesen: |

--- a/europace_security.yaml
+++ b/europace_security.yaml
@@ -31,7 +31,7 @@ flows:
       partner:rechte:schreiben: |
         ## Partner-Rechte verändern
       partner:zugang:silent-sign-on: |
-        ## Silent-Sign-On
+        ## Silent-Sign-On erlaubt
         Der Benutzer kann über die Silent-Sign-On API eingeloggt werden.
 
       report:rohdaten:lesen: |

--- a/europace_security.yaml
+++ b/europace_security.yaml
@@ -32,7 +32,7 @@ flows:
         ## Partner-Rechte verändern
       partner:zugang:silent-sign-on: |
         ## Silent-Sign-On erlaubt
-        Der Benutzer kann über die Silent-Sign-On API eingeloggt werden.
+        Ermöglicht das öffnen von Europace im Browser ohne Passwortabfrage.
 
       report:rohdaten:lesen: |
         ## Vertriebs-Rohdaten-Report abrufen


### PR DESCRIPTION
Closes [PARTNER-714]

## Motivation 

Wir erweitern das Partnermanagement, um einen Endpunkt für Silent-Sign-On. Der Endpunkt ermöglicht es OAuth-Clients ihre Nutzer auf der Plattform via API einzuloggen. Der Endpunkt prüft den Konsent des Nutzers über den Scope `partner:zugang:silent-sign-on`.
Siehe auch Story [PARTNER-646]

[PARTNER-714]: https://europace.atlassian.net/browse/PARTNER-714

[PARTNER-646]: https://europace.atlassian.net/browse/PARTNER-646