### PR TITLE
[MTV-265] Neuer Scope zum löschen eines bestehenden Vorgangs

### DIFF
--- a/docs/scopes.md
+++ b/docs/scopes.md
@@ -21,6 +21,7 @@ Die nachfolgende Tabelle stellt eine Liste, der aktuell verfügbaren Scopes dar.
 | ` baufinanzierung:echtgeschaeft ` |  BaufiSmart-Echtgeschäft bearbeiten  |    |
 | ` baufinanzierung:vorgang:lesen ` |  BaufiSmart-Vorgänge lesen  |    |
 | ` baufinanzierung:vorgang:schreiben ` |  BaufiSmart-Vorgänge anlegen  |    |
+| ` baufinanzierung:vorgang:loeschen ` |  BaufiSmart-Vorgänge löschen  |    |
 | ` baufinanzierung:angebot:ermitteln ` |  BaufiSmart-Angebote ermitteln  |    |
 | ` baufinanzierung:angebot:loeschen ` |  gespeicherte BaufiSmart-Angebote löschen  |    |
 | ` baufinanzierung:ereignis:lesen ` |  BaufiSmart-Ereignisse lesen  |    |

--- a/docs/scopes.md
+++ b/docs/scopes.md
@@ -21,7 +21,6 @@ Die nachfolgende Tabelle stellt eine Liste, der aktuell verfügbaren Scopes dar.
 | ` baufinanzierung:echtgeschaeft ` |  BaufiSmart-Echtgeschäft bearbeiten  |    |
 | ` baufinanzierung:vorgang:lesen ` |  BaufiSmart-Vorgänge lesen  |    |
 | ` baufinanzierung:vorgang:schreiben ` |  BaufiSmart-Vorgänge anlegen  |    |
-| ` baufinanzierung:vorgang:loeschen ` |  BaufiSmart-Vorgänge löschen  |    |
 | ` baufinanzierung:angebot:ermitteln ` |  BaufiSmart-Angebote ermitteln  |    |
 | ` baufinanzierung:angebot:loeschen ` |  gespeicherte BaufiSmart-Angebote löschen  |    |
 | ` baufinanzierung:ereignis:lesen ` |  BaufiSmart-Ereignisse lesen  |    |

--- a/europace_security.yaml
+++ b/europace_security.yaml
@@ -45,6 +45,8 @@ flows:
         ## BaufiSmart-Vorgänge lesen
       baufinanzierung:vorgang:schreiben: |
         ## BaufiSmart-Vorgänge anlegen
+      baufinanzierung:vorgang:loeschen: |
+        ## BaufiSmart-Vorgänge löschen
       baufinanzierung:angebot:ermitteln: |
         ## BaufiSmart-Angebote ermitteln
       baufinanzierung:angebot:loeschen: |


### PR DESCRIPTION
## Motivation
Wir erweitern die Vorgaenge-API um einen Endpunkt zum Löschen von Vorgängen. Der Endpunkt prüft die Berechtigung des Nutzers über den Scope `baufinanzierung:vorgang:loeschen`.
