### PR TITLE
[PASST-725] Scope für passende Vorschlaege ergänzt

### DIFF
--- a/europace_security.yaml
+++ b/europace_security.yaml
@@ -79,6 +79,9 @@ flows:
         ## Produktanbieter verändern
         für Product-Cockpit
 
+      baufinanzierung:passende-vorschlaege:ermitteln: |
+        ## passende Vorschläge ermitteln
+
       privatkredit:angebot:ermitteln: |
         ## KreditSmart-Angebote ermitteln
         Ratenkredit-Angebote und -Schaufensterkonditionen können ermittelt werden.


### PR DESCRIPTION
Mit diesem PR werden die Security Scopes um _passende-vorschlaege:ermitteln_ erweitert. 

Dies ist ein spezieller Scope für externe Partner zur Ermittlung der passenden Vorschläge. Wir brauchen eine Unterscheidung zwischen dem _baufinanzierung:angebote:ermitteln_ und diesem, um unter anderem Themen wie Monetarisierung zu ermöglichen.