### PR TITLE
Codeowners auf aktuellen Stand angepasst

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,1 @@
-* @caspii @ollio
-
-europace_security.yaml @ollio @sgrell @schmidthappens
+europace_security.yaml @schmidthappens


### PR DESCRIPTION
Olli und Caspar sind nicht mehr im Unternehmen, daher habe ich sie entfernt. Da es die Rolle OAuth-Scope-Master nicht mehr gibt, möchte ich mich hier auch aus den Codeownern rausnehmen.