### PR TITLE
switch2english

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,63 +1,63 @@
 # Authorization API
 
-Die Authorization-API stellt die Authentifizierung bei Europace für APIs zur Verfügung. Sie ist eine zwingende Voraussetzung zur Verwendung von Europace APIs.
+The Authorization API provides authentication to Europace for APIs. It is a mandatory requirement for using Europace APIs.
 
 
-![Vertrieb](https://img.shields.io/badge/-Vertrieb-lightblue)
-![Produktanbieter](https://img.shields.io/badge/-Produktanbieter-lightblue)
-![Baufinanzierung](https://img.shields.io/badge/-Baufinanzierung-lightblue)
-![Privatkredit](https://img.shields.io/badge/-Privatkredit-lightblue)
+![advisors](https://img.shields.io/badge/-advisors-lightblue)
+![loan providers](https://img.shields.io/badge/-loanProviders-lightblue)
+![mortgage loans](https://img.shields.io/badge/-mortgageLoans-lightblue)
+![consumer loans](https://img.shields.io/badge/-consumerLoans-lightblue)
 
-[![Authentication](https://img.shields.io/badge/Auth-OAuth2-green)](https://github.com/europace/authorization-api)
+[![authentication](https://img.shields.io/badge/Auth-OAuth2-green)](https://github.com/europace/authorization-api)
 
 [![GitHub release](https://img.shields.io/github/v/release/europace/authorization-api)](https://github.com/europace/authorization-api/releases)
 [![Pattern](https://img.shields.io/badge/Pattern-Tolerant%20Reader-yellowgreen)](https://martinfowler.com/bliki/TolerantReader.html)
 
-## Dokumentation
+## Documentation
 [![YAML](https://img.shields.io/badge/OAS-HTML_Doc-lightblue)](https://europace.github.io/authorization-api/oas-doc.html)
 [![YAML](https://img.shields.io/badge/OAS-YAML-lightgrey)](https://github.com/europace/authorization-api/blob/master/authorization.yaml)
 
-**weitere Artikel** 
+**related articles** 
 * Migrationsguide [deutsch](https://docs.api.europace.de/common/authentifizierung/oauth-migrationsguide) / [english](https://docs.api.europace.de/common/authentifizierung/oauth-migrationsguide_en).
-* HowTo implement [auth-code-flow (english)](https://docs.api.europace.de/common/authentifizierung/oauth-code-flow_en/)
+* HowTo implement [auth-code-flow](https://docs.api.europace.de/common/authentifizierung/oauth-code-flow_en/)
 
-## Anwendungsfälle
-- Benutzer anmelden, um Europace-APIs zu verwenden
+## Usecases
+- login user to use europace-apis with his identity
 
-## Schnellstart
-Damit du unsere APIs und deinen Anwendungsfall schnellstmöglich testen kannst, haben wir eine [Postman-Collection](https://github.com/europace/api-schnellstart) für dich zusammengestellt.
+## Quickstart
+To test our APIs and your use case as quickly as possible, we've put together a [Postman Collection](https://github.com/europace/api-schnellstart) for you.
 
-## Wie benutze ich OAuth2?
+## How to use OAuth2?
 
-Alle Europace-APIs sind zugangsbeschränkt, d.h. um sie verwenden zu können muss zuvor eine Anmeldung (Authentifizierung) bei Europace erfolgen.
+All Europace APIs are access restricted, i.e. in order to use them a login (authentication) to Europace has to be done first.
 
-Dabei müssen folgende Schritte durchlaufen werden:
-- Einmalig musst du deinen Client in Europace registrieren lassen, woraufhin du die `Client_ID` und das `Client-Secret` für den Client erhältst
-- Für die Anmeldung an Europace rufst du `https://api.europace.de/auth/token` mit der `Client_ID` und dem `Client_Secret` als Basic-Auth auf, um einen `Access_Token` zu erhalten. Die meisten HTTP Clients unterstützen OAuth2 bereits und lassen sich mit diesen Parametern konfigurieren.
-- Mit dem `Access_Token` als Bearer-Token kannst du Requests an den Europace APIs durchführen.
-Request-Header-Variable:  `Authorization: Bearer [Access_Token]`
+Follow these steps:
+- you have to register your client once in Europace, whereupon you will receive the `Client_ID` and the `Client-Secret` for the client.
+- To log in to Europace, call `https://api.europace.de/auth/token` with the `Client_ID` and the `Client_Secret` as Basic-Auth to get an `access_token`. Most HTTP clients already support OAuth2 and can be configured with these parameters.
+- With the `access_token` as a bearer token you can make requests to the Europace APIs.
+Request header variable: `Authorization: Bearer [access_token]`
 
-## Wie bekomme ich einen Client registriert?
+## How to register your client?
 
-<a href="mailto:helpdesk@europace2.de?subject=Registrierung API-Client&body=Hallo,%0D%0Abitte%20registriert%20einen%20API-Client%20für%20mich.%0D%0A%0D%0APartnerID:%0D%0AClient-Name:%0D%0AClient-Beschreibung:%0D%0Atechnische%20Kontakt-Email-Adresse:%0D%0Akurze%20Beschreibung%20des%20Anwendungsfalls:%0D%0Abenötigte%20Scopes:%0D%0A%0D%0AVielen%20Dank">zur Client-Registrierung</a>
+<a href="mailto:helpdesk@europace2.de?subject=Registrierung API-Client&body=Hallo,%0D%0Abitte%20registriert%20einen%20API-Client%20für%20mich.%0D%0A%0D%0APartnerID:%0D%0AClient-Name:%0D%0AClient-Beschreibung:%0D%0Atechnische%20Kontakt-Email-Adresse:%0D%0Akurze%20Beschreibung%20des%20Anwendungsfalls:%0D%0Abenötigte%20Scopes:%0D%0A%0D%0AVielen%20Dank">apply client-registration</a>
 
 
-Bitte wende dich an <a href="mailto:helpdesk@europace2.de?subject=Registrierung API-Client&body=Hallo,%0D%0Abitte%20registriert%20einen%20API-Client%20für%20mich.%0D%0A%0D%0APartnerID:%0D%0AClient-Name:%0D%0AClient-Beschreibung:%0D%0Atechnische%20Kontakt-Email-Adresse:%0D%0Akurze%20Beschreibung%20des%20Anwendungsfalls:%0D%0Abenötigte%20Scopes:%0D%0A%0D%0AVielen%20Dank">helpdesk@europace.de</a> mit folgenden Daten:
-- EP2-PartnerId
-- Client-Name
-- Client-Beschreibung:
-- Kontakt-Email-Adresse für betriebliche Rückfragen
-- Kurze Beschreibung des Anwendungsfalls (Ziel)
-- benötigte Scopes
+Please contact <a href="mailto:helpdesk@europace2.de?subject=Registrierung API-Client&body=Hello,%0D%0Please%20register%20an%20API-Client%20for%20me. %0D%0A%0D%0APartnerID:%0D%0AClientName:%0D%0AClientDescription:%0D%0Atechnical%20contact email address:%0D%0Short%20description%20of%20the%20application:%0D%0Required%20Scopes:%0D%0A%0D%0AVever%20Thanks">helpdesk@europace.de</a> with the following data:
+- EP2 PartnerId
+- Client name
+- Client Description:
+- Contact email address for operational queries
+- Short description of the use case (goal)
+- required scopes
 
-Nach einer kurzen Prüfung beim Eigentümer (Europace Partner) registrieren wir dir deinen Client umgehend und stellen dir die Client-ID und das Client-Secret in deiner persönlichen Linkliste in Europace zur Verfügung.
+After a short check with the owner (Europace partner) we will register your client immediately and provide you with the client ID and client secret in your personal link list in Europace.
 
 ![Linksammlung.png](https://docs.api.europace.de/Linksammlung.png "Linksammlung")
 
-Bitte beachte, dass du dich mit der Benutzung der APIs automatisch mit den [Europace API-Nutzungsbedingungen](https://docs.api.europace.de/nutzungsbedingungen/) einverstanden erklärst.
+Please note that by using the APIs, you automatically agree to the [Europace API Terms of Use](https://docs.api.europace.de/nutzungsbedingungen/).
 
-## Wie bekomme ich einen Access-Token?
-Für die Anmeldung an Europace rufst du `https://api.europace.de/auth/token` mit der `Client_ID` und dem `Client_Secret` als Basic-Auth auf, um einen Access_Token zu erhalten.
+## How to get an access-token?
+To log in to Europace, call `https://api.europace.de/auth/token` with the `Client_ID` and the `Client_Secret` as Basic-Auth to get an Access_Token.
 
 Request:
 ```cURL
@@ -75,35 +75,35 @@ Response:
    "expires_in": 3600   }
 ```
 
-In diesem Fall wird ein Access-Token im Namen und im Auftrag des Partners erstellt an dem der Client registriert ist. Weitere Anwendungsfälle werden in “Alte Welt - neue Welt” behandelt.
+In this case, an access token is created in the name and on behalf of the partner to which the client is registered. Further use cases are discussed in "Old world - new world".
 
-Neben dem Grant-Type werden folgende Request-Parameter unterstützt:
+In addition to the grant type, the following request parameters are supported:
 
 - ##### Grant-Type (`grant_type`)
-  [OAuth2.0 Grant-Type][RFC6749#4], muss für den Client-Credentials-Flow `client_credentials` sein.
-- ##### Scopes (`scope`)
-  "` `"-separierte Liste von Scopes. Wird ein Subject angegeben muss `impersonieren` als Scope enthalten sein.
-  Angefragte Scopes werden entsprechend der Rechte des Akteurs und dem Client-Approval durch den Akteur eingeschränkt. Es ist möglich einen eingeschränkten Zugriff anzufragen, in dem man spezifische Scopes angibt. Ein Scope stellt eine Berechtigung zum Ausführen von Aktionen auf der Plattform dar. Werden keine Scopes angefragt ergibt sich der Scope aus den bei der Client-Registrierung hinterlegten Scopes. Die aktuell verfügbaren Scopes werden in einer [Übersicht](https://github.com/europace/authorization-api/blob/master/docs/scopes.md) gepflegt.
-- ##### Akteur (`actor`)
-  Partner-Id des Partners in dessen Auftrag der Client agiert, es muss ein
-  Client-Approval des Akteurs für den Client vorliegen. Aktuell wird der Client-Approval automatisch bei der Registrierung für den Aktuer und alle Subjects im Zugriffsbereich des Clients erteilt .
+  [OAuth2.0 Grant-Type][RFC6749#4], must be `client_credentials` for client credentials flow.
+- ##### Scopes (`scope`).
+  "` `"-separated list of scopes. If a subject is specified, `impersonate` must be included as a scope.
+  Requested scopes are restricted according to the actor's permissions and the client's approval by the actor. It is possible to request restricted access by specifying specific scopes. A scope represents an authorization to perform actions on the platform. If no scopes are requested, the scope results from the scopes stored during client registration. The currently available scopes are maintained in an [Overview](https://github.com/europace/authorization-api/blob/master/docs/scopes.md).
+- ##### Actor (`actor`)
+  Partner id of the partner on whose behalf the client is acting, there must be a
+  client-approval of the actor for the client. Currently the client-approval is granted automatically during registration for the actor and all subjects in the access area of the client.
 - ##### Subject (`subject`)
-  Partner-Id des Partners in dessen Namen der Client agiert. Das Subject muss dem Akteur untergeordnet sein.
+  Partner id of the partner on whose behalf the client acts. The subject must be subordinate to the actor.
 
-## Wie rufe ich eine API mit Access-Token auf?
-Mit dem Access_Token als Bearer-Token kannst du Requests an den Europace APIs durchführen.
-Request-Header-Variable:  `Authorization: Bearer [Access_Token]`
+## How to call an API with access-token?
+With the Access_Token as a Bearer token you can make requests to the Europace APIs.
+Request header variable: `Authorization: Bearer [access_token]`
 
-Am Beispiel der Vorgaenge-API in curl:
+Using the example of the process API in curl:
 ```cURL
 curl --location --request GET 'https://api.europace2.de/v2/vorgaenge' \
 --header 'Content-Type: application/json' \
---header 'Authorization: Bearer [Access_Token]
+--header 'Authorization: Bearer [access_token]
 ```
 
-## Wie authentifiziere ich verschiedene Benutzer mit einem Client? (Impersionieren)
+## How to authenticate different users with one client? (Impersonation)
 
-Das impersionierte OAuth2-Verfahren wird dann verwendet, wenn die API den konkreten Benutzer benötigt und man nicht für jeden Benutzer einen Client registrieren möchte. Es reicht einen Client für die Organisation zu haben, der als Generalsschlüssel fungiert und mit dem Benutzer, auf die die Organisation Zugriff hat, angemeldet werden können.
+The imperseded OAuth2 method is used when the API needs the specific user and you don't want to register a client for each user. It is enough to have one client for the organization that acts as a general key and can be used to log in users that the organization has access to.
 
 ```cURL
 curl --location --request POST 'https://api.europace.de/auth/token' \
@@ -111,22 +111,21 @@ curl --location --request POST 'https://api.europace.de/auth/token' \
 --header 'Content-Type: application/x-www-form-urlencoded' \
 --data-urlencode 'grant_type=client_credentials' \
 --data-urlencode 'scope=impersonieren baufinanzierung:echtgeschaeft baufinanzierung:vorgang:lesen baufinanzierung:ereignis:lesen baufinanzierung:antrag:lesen' \
---data-urlencode 'subject=[anzumeldende PartnerID]' \
---data-urlencode 'actor=[registrierte PartnerID]'
+--data-urlencode 'subject=[to be login PartnerID]' \
+--data-urlencode 'actor=[registered PartnerID]'
 ```
 
-
-Parameter | Beschreibung |
+Parameters | Description |
 --------- | :--- |
-Subject   | die PartnerID des anzumeldenden Benutzers
-Actor     | die PartnerID des registrierten Clients<br/><br/>**Hinweis**: Die Actor-Partnerid muss in der Partnermanagementstruktur über der Subject-Partnerid angeordnet sein, da sonst die notwendigen Zugriffsrechte fehlen. Es können beliebig viele Ebenen zwischen den Partnerids liegen.
-Scope     | benötigten Scopes des Tokens<br/><br/>**Hinweis**: Der Scope `impersonieren` muss immer enthalten sein. Alle angegebenen Scopes müssen beim Client aktiviert sein.
+Subject | the PartnerID of the user to be registered
+Actor | the partnerID of the registered client<br/><br/>**Note**: The Actor partnerid must be placed above the Subject partnerid in the partner management structure, otherwise the necessary access rights are missing. There can be any number of scopes between the partnerids.
+Scope | required scopes of the token<br/><br/>**Note**: The scope `impersonate` must always be included. All specified scopes must be enabled at the client.
 
-## Nutzungsbedingungen
-Die APIs werden unter folgenden [Nutzungsbedingungen](https://docs.api.europace.de/nutzungsbedingungen/) zur Verfügung gestellt.
+## Terms of use
+The APIs are made available under the following [Terms of Use](https://docs.api.europace.de/nutzungsbedingungen/).
 
 ## Support
-Bei Fragen oder Problemen kannst du dich an devsupport@europace2.de wenden.
+If you have any questions or problems, you can contact devsupport@europace2.de.
 
 [JWT]: https://tools.ietf.org/html/rfc7519
 [ASCII]: http://www.ecma-international.org/publications/files/ECMA-ST/Ecma-006.pdf

--- a/authorization.yaml
+++ b/authorization.yaml
@@ -1,8 +1,8 @@
 openapi: 3.0.0
 info:
   title: Europace Authorization API
-  description: Mit diesem Service lassen sich Access Tokens von registrierten Clients anfordern um die Europace APIs zu verwenden.
-  version: '0.1'
+  description: The authorization-api can be requested to get an access-token from registered clients with client-credential-flow to use the Europace APIs.
+  version: '1.0'
   termsOfService: 'https://docs.api.europace.de/nutzungsbedingungen/'
   contact:
     name: Europace AG
@@ -10,19 +10,19 @@ info:
     email: devsupport@europace2.de
 servers:
   - url: 'https://api.europace.de/auth'
-    description: Produktiv Server
+    description: production server
 paths:
   /token:
     post:
-      summary: Access Token anfordern (login)
-      description: Client-Id und Client-Secret müssen per HTTP Basic Auth übergeben werden.
+      summary: login
+      description: Client-id and client-secret must be passed via HTTP Basic Auth.
       parameters:
         - schema:
             type: string
             default: mytraceid123
           in: header
           name: X-TraceId
-          description: 'Frei-wählbarer String, um Debugging zu vereinfachen'
+          description: your string for debugging
         - schema:
             type: string
             default: application/x-www-form-urlencoded
@@ -40,7 +40,7 @@ paths:
             examples: {}
         description: ''
       tags:
-        - authz
+        - Auth
       responses:
         '200':
           description: OK
@@ -49,7 +49,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/loginResponse'
         '400':
-          description: Bad Request. zB nicht existierende Scopes angefordert
+          description: Bad Request. e.g. not existing scopes requested
           content:
             application/json:
               schema:
@@ -68,7 +68,7 @@ paths:
                     error_description: 'Invalid, unknown or malformed scope'
                     error: invalid_scope
         '401':
-          description: 'Unauthorized. Autorisierungsfehler bei den Client Credentials '
+          description: Unauthorized. Client credentials authorization error
           content:
             application/json:
               schema:
@@ -79,11 +79,12 @@ paths:
                     error_description: 'Client authentication failed: Client id unknown / deactivated or client secret invalid / expired.'
                     error: invalid_client
         '429':
-          description: Too Many Requests. Rate-Limit überschritten.
+          description: Too Many Requests. Rate limit exceeded.
         '500':
-          description: Internal Server Error. Autsch.
+          description: Internal Server Error. Ooops.
         '503':
           description: Service Unavailable
+      operationId: createToken
     parameters: []
 components:
   securitySchemes:
@@ -97,17 +98,17 @@ components:
       properties:
         access_token:
           type: string
-          description: Access-Token für die Verwendung als Bearer Token in den Europace-APIs
+          description: Access token for use as a bearer token in the Europace APIs.
         token_type:
           type: string
           default: BEARER
-          description: Typ des Token (BEARER)
+          description: Type of Token (BEARER)
         expires_in:
           type: integer
-          description: Gültigkeitsdauer in Sekunden
+          description: Validity period in seconds
         scope:
           type: string
-          description: Gültige Scopes des Access-Token
+          description: Valid scopes of the access token
       required:
         - access_token
         - token_type
@@ -119,27 +120,30 @@ components:
           token_type: BEARER
           expires_in: 3600
           scope: no-access
-      description: Antwort eines erfolgreichen Logins
+      description: Response of a successful login
     loginRequest:
       title: loginRequest
       type: object
-      description: "Parameter für das Login. Im einfachsten Fall wird grant_type=client_credential übergeben. \n\nBeim Impersonieren müssen subject, actor und als scope impersonieren sowie alle anderen benötigten Scopes mit angebenen werden."
+      description: |-
+        Parameters for the login. In the simplest case grant_type=client_credential is passed. 
+
+        When impersonating, subject, actor and impersonate as scope as well as all other required scopes must be specified.
       x-examples: {}
       properties:
         grant_type:
           type: string
           default: client_credentials
-          description: Muss für den Client-Credentials-Flow `client_credentials` sein.
+          description: Must be `client_credentials` for the client credentials flow.
         scope:
           type: string
-          default: no-access impersionieren
-          description: '" "-separierte Liste von Scopes. Wird ein Subject angegeben muss impersonieren als Scope enthalten sein. Angefragte Scopes werden entsprechend der Rechte des Akteurs und dem Client-Approval durch den Akteur eingeschränkt. Es ist möglich einen eingeschränkten Zugriff anzufragen, in dem man spezifische Scopes angibt. Ein Scope stellt eine Berechtigung zum Ausführen von Aktionen auf der Plattform dar. Werden keine Scopes angefragt ergibt sich der Scope aus den bei der Client-Registrierung hinterlegten Scopes. Die aktuell verfügbaren Scopes werden in einer Übersicht gepflegt.'
+          default: no-access impersonieren
+          description: 'space-separated list of scopes. If a subject is specified, impersonate must be included as a scope. Requested scopes are restricted according to the actor''s permissions and the client''s approval by the actor. It is possible to request restricted access by specifying specific scopes. A scope represents an authorization to perform actions on the platform. If no scopes are requested, the scope is derived from the scopes stored during client registration. The currently available scopes are maintained in an overview.'
         subject:
           type: string
-          description: Partner-Id des Partners in dessen Namen der Client agiert. Das Subject muss dem Akteur untergeordnet sein.
+          description: Partner id of the partner on whose behalf the client acts. The subject must be subordinate to the actor.
         actor:
           type: string
-          description: 'Partner-Id des Partners in dessen Auftrag der Client agiert, es muss ein Client-Approval des Akteurs für den Client vorliegen.'
+          description: 'Partner id of the partner on whose behalf the client is acting, there must be a client approval of the actor for the client.'
       required:
         - grant_type
     error:
@@ -153,4 +157,4 @@ components:
       required:
         - error_description
         - error
-      description: Inhaltliche Fehlermeldung zusätzlich zum HTTP-Fehlercode.
+      description: Content error message in addition to HTTP error code.

--- a/docs/silent-sign-in/README.md
+++ b/docs/silent-sign-in/README.md
@@ -1,76 +1,76 @@
 # Silent-Sign-In API
 
-Die Silent-Sign-In API von Europace ermöglicht das Anmelden von Benutzern durch einen OAuth-Client und den Aufruf der Europace-Benutzeroberfläche im Browser.
+Europace's Silent Sign-In API allows users to sign in through an OAuth client and invoke the Europace user interface in the browser.
 
 ---- 
-![Vertrieb](https://img.shields.io/badge/-Vertrieb-lightblue)
-![Produktanbieter](https://img.shields.io/badge/-Produktanbieter-lightblue)
-![Baufinanzierung](https://img.shields.io/badge/-Baufinanzierung-lightblue)
-![Privatkredit](https://img.shields.io/badge/-Privatkredit-lightblue)
+![advisor](https://img.shields.io/badge/-advisor-lightblue)
+![loanProvider](https://img.shields.io/badge/-loanProvider-lightblue)
+![mortgageLoans](https://img.shields.io/badge/-mortgageLoans-lightblue)
+![consumerLoans](https://img.shields.io/badge/-consumerLoans-lightblue)
 
 [![Authentication](https://img.shields.io/badge/Auth-OAuth2-green)](https://docs.api.europace.de/baufinanzierung/authentifizierung/)
 ![Release](https://img.shields.io/badge/release-1.0-blue)
 
-## Anwendungsfälle der API
+## Usecases
 
-- einen Benutzer anmelden und Europace nahtlos in einem iFrame oder neuen Browser-Tab anzeigen
+- Log in a user and display Europace seamlessly in an iFrame or new browser tab.
 
 ## Dokumentation
 [![YAML](https://img.shields.io/badge/OAS-HTML_Doc-lightblue)](https://europace.github.io/authorization-api/ssi.html)
 [![YAML](https://img.shields.io/badge/OAS-YAML-lightgrey)](https://github.com/europace/authorization-api/blob/master/docs/silent-sign-in/ssi-openapi.yaml)
 
-Feedback und Fragen sind als [GitHub Issue](https://github.com/europace/authorization-api/issues/new) willkommen.          |
+Feedback and questions are welcome as [GitHub Issue](https://github.com/europace/authorization-api/issues/new).
 
 
-## Ablauf des Silent-Sign-In
+## Steps of the Silent Sign-In
 ![seq-ssi](seq_ssi.png)
 
-## Beispiel: Benutzer anmelden und Vorgang öffnen
+## Example: Log on user and open process
 
-### Schritt 1 - Benutzer anmelden
-Der Schritt ist optional, wenn bereits ein User-Access-Token vorliegt.
+### Step 1 - Login user
+The step is optional if a user access token already exists.
 
-Um die API verwenden zu können, benötigt der OAuth2-Client folgende Scopes:
+To use the API, the OAuth2 client requires the following scopes:
 | Scope                                  | API-Usecase                                                      |
 | -------------------------------------- | ---------------------------------------------------------------- |
-| ` partner:login:silent-sign-in `       |   Silent-Sign-In erlaubt                                         |
-| ` impersonieren `                      |   Andere Benutzer als subject anmelden       
+| ` partner:login:silent-sign-in `       |   Silent sign-in allowed                                         |
+| ` impersonieren `                      |   Log in other users as subject       
 
-> **Wichtig:** der Access-Token muss im Namen des Benutzers ausgestellt sein. 
-Um diesen als Client zu erzeugen, kann das Impersonieren angewendet werden. Siehe: [Authorization-API-Impersonieren](https://docs.api.europace.de/common/authentifizierung/authorization-api/#wie-authentifiziere-ich-verschiedene-benutzer-mit-einem-client-impersionieren)
+> The access token must be issued in the name of the user. 
+Impersonation can be applied to create this as a client. See: [Authorization API Impersonate](https://docs.api.europace.de/common/authentifizierung/authorization-api/#wie-authentifiziere-ich-verschiedene-benutzer-mit-einem-client-impersionieren)
 
-### Schritt 2 - One-Time-Password erzeugen
-Aus Sicherheitgründen wird ein One-Time-Password für den Aufruf von Europace über den Browser verwendet.
+### Step 2 - Generate one-time password
+For security reasons, a one-time password is used to access Europace via the browser.
 
-Beispiel-Request:
+Example-request:
 ``` http
 POST /authorize/silent-sign-in?subject=[user-partner-id] HTTP/1.1
 Host: www.europace2.de
 Authorization: Bearer [user-access-token]
 ```
 
-Beispiel-Resonse:
+Example-resonse:
 ``` json
 {
   "otp": "05448389A4014F49AFC896EB15B60A07AE8B"
 }
 ```
 
-### Schritt 3 - Europace öffnen
-Mit dem OTP kann nun Europace geöffnet werden. Um den Vorgang AB45C2 direkt anzuzeigen, wird die redirect_uri mit `/vorgang/oeffne/[vorgangsnummer]` übergeben werden.
+### Step 3 - Open Europace in the browser
+Europace can now be opened with the OTP. To display the process AB45C2 directly, the redirect_uri will be passed with `/vorgang/oeffne/[vorgangsnummer]`.
 
-Beispiel-Request:
+Example-request:
 ``` http
 GET /authorize/silent-sign-in?subject=[user-partner-id]&redirect_uri=/vorgang/oeffne/AB45C2&otp=[otp] HTTP/1.1
 Host: www.europace2.de
 ```
 
-Beispiel-Resonse:
-Redirect mit EP-Session auf `https://www.europace2.de/[redirect_uri]`
+Example-response: \
+Redirect with EP session to `https://www.europace2.de/[redirect_uri]`
 
-Liste der Redirect_uris:
+List of Redirect_uris:
 * `/uebersicht` (default)
 * `/vorgangsmanagement`
 * `/vorgang/oeffne/[vorgangsnummer]`
-* `/antragsuebersicht` (nur für Produktanbieter)
+* `/antragsuebersicht` (for product providers only)
 * `/partnermanagement` 

--- a/docs/silent-sign-in/ssi-openapi.yaml
+++ b/docs/silent-sign-in/ssi-openapi.yaml
@@ -4,7 +4,7 @@ tags:
 info:
   title: ssi-api
   version: v1.0
-  description: Die Silent-Sign-In API von Europace ermöglicht das Anmelden von Benutzern durch einen OAuth-Client und den Aufruf der Europace-Benutzeroberfläche im Browser.
+  description: Europace's Silent Sign-In API allows users to sign in through an OAuth client and invoke the Europace user interface in the browser.
   contact:
     name: Europace AG
     url: 'http://docs.api.europace.de'
@@ -12,7 +12,7 @@ info:
   termsOfService: 'https://docs.api.europace.de/nutzungsbedingungen/'
 servers:
   - url: 'https://www.europace2.de/authorize'
-    description: Production Server
+    description: production server
 externalDocs:
   url: 'https://docs.api.europace.de/common/authentifizierung/ssi-api/'
 paths:
@@ -23,7 +23,7 @@ paths:
       operationId: create-ssi-otp
       responses:
         '200':
-          description: Created - otp wurde erzeugt
+          description: Created - otp created
           content:
             application/json:
               schema:
@@ -33,21 +33,21 @@ paths:
                   value:
                     otp: EGSY53CGGSXZBWGMSPBZD2ILAKCF6J53
         '401':
-          description: Unauthorized - access-token ist abgelaufen
+          description: Unauthorized - access-token has expired
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
         '403':
-          description: Forbidden - Scopes silent-sign-on ist nicht vorhanden
+          description: Forbidden - Scopes silent-sign-on is not present
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
       description: |-
-        Erzeugt on-time-password (otp) aus dem access-token für den Browser-Redirect. 
+        Generates on-time-password (otp) from the access-token for the browser redirect. 
 
-        Ist der OAuth-Client auf einer Organisation registriert, so muss für den Benutzer mit dem Client impersoniert werden. Als Benutzer des Silent-Sign-In wird der Subject des access-token verwendet. Als Sicherheit wird das Subject zusätzlich als Parameter erwartet und geprüft. 
+        If the OAuth client is registered on an organization, then impersonation must be done for the user with the client. The subject of the access-token is used as the user of the silent sign-in. As security, the subject is also expected and checked as a parameter. 
       security:
         - europace_oauth2: []
       tags:
@@ -58,6 +58,7 @@ paths:
           in: query
           name: subject
           description: subject to sign-in
+          required: true
     get:
       summary: open Silent-Sign-In
       operationId: open-ssi
@@ -71,7 +72,7 @@ paths:
                 format: uri-reference
               description: redirect_uri with Session
         '403':
-          description: Forbidden - otp ungültig
+          description: Forbidden - otp invalid
           content:
             application/json:
               schema:
@@ -83,7 +84,7 @@ paths:
             format: uri-reference
           in: query
           name: redirect_uri
-          description: relative uri von Europace
+          description: relative uri from Europace
           required: true
         - schema:
             type: string
@@ -99,7 +100,8 @@ paths:
           in: query
           name: subject
           description: subject to sign-in
-      description: 'Browser-Endpunkt, der das One-Time-Password prüft und auf den angeforderten Endpunkt mit einer Europace-Session umlenkt.'
+          required: true
+      description: Browser endpoint that checks the one-time password and redirects to the requested endpoint with a Europace session.
       tags:
         - Silent-Sign-In
 components:


### PR DESCRIPTION
- readme.md übersetzt
- yaml übersetzt
- europace-security.yaml wurde nicht übersetzt, damit Benutzer weiterhin deutsche Beschreibungen der Scopes haben
