### PR TITLE
[DEVPRO-991] Fix Format für OTP

### DIFF
--- a/docs/silent-sign-in/ssi-openapi.yaml
+++ b/docs/silent-sign-in/ssi-openapi.yaml
@@ -87,7 +87,6 @@ paths:
           required: true
         - schema:
             type: string
-            format: uuid
             minLength: 32
             maxLength: 32
           in: query
@@ -116,7 +115,6 @@ components:
       properties:
         otp:
           type: string
-          format: uuid
           minLength: 32
           maxLength: 32
           description: one-time-password


### PR DESCRIPTION
Closes [DEVPRO-991]

Das OTP ist nur ein alphanumerischer kryptografischer Random-String der Länge 32 ist, kein UUID.



[DEVPRO-991]: https://europace.atlassian.net/browse/DEVPRO-991?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ