### PR TITLE
[PASST-2643] Neue Scopes für die passt API und BaufiPasst 

### DIFF
--- a/europace_security.yaml
+++ b/europace_security.yaml
@@ -55,7 +55,7 @@ flows:
         ## BaufiSmart-Anträge lesen
       baufinanzierung:antrag:schreiben: |
         ## BaufiSmart-Anträge verändern
-        Der Antragsstatus und der Sachbearbeiter können verändert sowie die Produktanbieter-Renferenz ergänzt werden.
+        Der Antragsstatus und der Sachbearbeiter können verändert sowie die Produktanbieter-Referenz ergänzt werden.
       
       baufinanzierung:produktkonfiguration:lesen: |
         ## Produktkonfiguration lesen
@@ -78,6 +78,12 @@ flows:
       baufinanzierung:produktanbieter:schreiben: |
         ## Produktanbieter verändern
         für Product-Cockpit
+      baufinanzierung:passende-vorschlaege:ermitteln: |
+        ## Passende Vorschläge ermitteln
+        für Passende Vorschläge API
+      baufinanzierung:baufi-passt:konfigurieren: |
+        ## BaufiPasst konfigurieren
+        für BaufiPasst Frontend
 
       privatkredit:angebot:ermitteln: |
         ## KreditSmart-Angebote ermitteln


### PR DESCRIPTION
[PASST-2643] Neue Scopes für die passt API (zwecks künftige Monetarisierung) und für die Konfiguration des BaufiPasst Frontends 

[PASST-2643]: https://europace.atlassian.net/browse/PASST-2643?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ