### PR TITLE
Update description of scope 

### DIFF
--- a/europace_security.yaml
+++ b/europace_security.yaml
@@ -35,7 +35,7 @@ flows:
         Ermöglicht das öffnen von Europace im Browser ohne Passwortabfrage.
 
       report:rohdaten:lesen: |
-        ## Vertriebs-Rohdaten-Report abrufen
+        ## Vertriebs-Reports abrufen
       report:produktanbieter:lesen: |
         ## Produktanbieter-Report abrufen
 


### PR DESCRIPTION
For the GRETA-Vertreibsreport, we want to reuse the scope `report:rohdaten:lesen` (see  [MTVLRR-87]).

[MTVLRR-87]: https://europace.atlassian.net/browse/MTVLRR-87?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ