### PR TITLE
[PASST-2643] Neues Scope für die Konfiguration des BaufiPasst Frontends

### DIFF
--- a/europace_security.yaml
+++ b/europace_security.yaml
@@ -78,10 +78,8 @@ flows:
       baufinanzierung:produktanbieter:schreiben: |
         ## Produktanbieter verändern
         für Product-Cockpit
-      baufinanzierung:passende-vorschlaege:ermitteln: |
-        ## Passende Vorschläge ermitteln
-        für Passende Vorschläge API
-      baufinanzierung:baufi-passt:konfigurieren: |
+
+      baufi-passt:konfiguration:schreiben: |
         ## BaufiPasst konfigurieren
         für BaufiPasst Frontend
 

--- a/europace_security.yaml
+++ b/europace_security.yaml
@@ -55,7 +55,7 @@ flows:
         ## BaufiSmart-Anträge lesen
       baufinanzierung:antrag:schreiben: |
         ## BaufiSmart-Anträge verändern
-        Der Antragsstatus und der Sachbearbeiter können verändert sowie die Produktanbieter-Renferenz ergänzt werden.
+        Der Antragsstatus und der Sachbearbeiter können verändert sowie die Produktanbieter-Referenz ergänzt werden.
       
       baufinanzierung:produktkonfiguration:lesen: |
         ## Produktkonfiguration lesen
@@ -78,6 +78,12 @@ flows:
       baufinanzierung:produktanbieter:schreiben: |
         ## Produktanbieter verändern
         für Product-Cockpit
+      baufinanzierung:passende-vorschlaege:ermitteln: |
+        ## Passende Vorschläge ermitteln
+        für Passende Vorschläge API
+      baufinanzierung:baufi-passt:konfigurieren: |
+        ## BaufiPasst konfigurieren
+        für BaufiPasst Frontend
 
       privatkredit:angebot:ermitteln: |
         ## KreditSmart-Angebote ermitteln


### PR DESCRIPTION
Nach Absprache mit PO, brauchen wir an erster Stelle die Absicherung der neuen BaufiPasst Admin API. 

